### PR TITLE
Fix syntax error

### DIFF
--- a/Sources/NostrSDK/Nostr.swift
+++ b/Sources/NostrSDK/Nostr.swift
@@ -1199,8 +1199,8 @@ open class EncryptedSecretKey:
     /**
      * Encrypt secret key
      */
-public convenience init(secretKey: SecretKey, password: String, logN: UInt8, keySecurity: KeySecurity) {
-    let pointer = throws try rustCallWithError(FfiConverterTypeNostrError.lift) {
+public convenience init(secretKey: SecretKey, password: String, logN: UInt8, keySecurity: KeySecurity) throws  {
+    let pointer = try rustCallWithError(FfiConverterTypeNostrError.lift) {
     uniffi_nostr_ffi_fn_constructor_encryptedsecretkey_new(
         FfiConverterTypeSecretKey.lower(secretKey),
         FfiConverterString.lower(password),
@@ -2590,8 +2590,8 @@ open class EventId:
     public func uniffiClonePointer() -> UnsafeMutableRawPointer {
         return try! rustCall { uniffi_nostr_ffi_fn_clone_eventid(self.pointer, $0) }
     }
-public convenience init(publicKey: PublicKey, createdAt: Timestamp, kind: Kind, tags: [Tag], content: String) {
-    let pointer = throws try rustCallWithError(FfiConverterTypeNostrError.lift) {
+public convenience init(publicKey: PublicKey, createdAt: Timestamp, kind: Kind, tags: [Tag], content: String) throws  {
+    let pointer = try rustCallWithError(FfiConverterTypeNostrError.lift) {
     uniffi_nostr_ffi_fn_constructor_eventid_new(
         FfiConverterTypePublicKey.lower(publicKey),
         FfiConverterTypeTimestamp.lower(createdAt),
@@ -2816,8 +2816,8 @@ open class FileMetadata:
     public func uniffiClonePointer() -> UnsafeMutableRawPointer {
         return try! rustCall { uniffi_nostr_ffi_fn_clone_filemetadata(self.pointer, $0) }
     }
-public convenience init(url: String, mimeType: String, hash: String) {
-    let pointer = throws try rustCallWithError(FfiConverterTypeNostrError.lift) {
+public convenience init(url: String, mimeType: String, hash: String) throws  {
+    let pointer = try rustCallWithError(FfiConverterTypeNostrError.lift) {
     uniffi_nostr_ffi_fn_constructor_filemetadata_new(
         FfiConverterString.lower(url),
         FfiConverterString.lower(mimeType),
@@ -4830,8 +4830,8 @@ open class Nip19Profile:
     /**
      * New NIP19 profile
      */
-public convenience init(publicKey: PublicKey, relays: [String]) {
-    let pointer = throws try rustCallWithError(FfiConverterTypeNostrError.lift) {
+public convenience init(publicKey: PublicKey, relays: [String]) throws  {
+    let pointer = try rustCallWithError(FfiConverterTypeNostrError.lift) {
     uniffi_nostr_ffi_fn_constructor_nip19profile_new(
         FfiConverterTypePublicKey.lower(publicKey),
         FfiConverterSequenceString.lower(relays),$0
@@ -5621,8 +5621,8 @@ open class NostrWalletConnectUri:
     /**
      * Create new Nostr Wallet Connect URI
      */
-public convenience init(publicKey: PublicKey, relayUrl: String, randomSecretKey: SecretKey, lud16: String?) {
-    let pointer = throws try rustCallWithError(FfiConverterTypeNostrError.lift) {
+public convenience init(publicKey: PublicKey, relayUrl: String, randomSecretKey: SecretKey, lud16: String?) throws  {
+    let pointer = try rustCallWithError(FfiConverterTypeNostrError.lift) {
     uniffi_nostr_ffi_fn_constructor_nostrwalletconnecturi_new(
         FfiConverterTypePublicKey.lower(publicKey),
         FfiConverterString.lower(relayUrl),

--- a/Sources/NostrSDK/NostrSDK.swift
+++ b/Sources/NostrSDK/NostrSDK.swift
@@ -1606,8 +1606,8 @@ open class Nwc:
     /**
      * Compose new `NWC` client
      */
-public convenience init(uri: NostrWalletConnectUri) {
-    let pointer = throws try rustCallWithError(FfiConverterTypeNostrSdkError.lift) {
+public convenience init(uri: NostrWalletConnectUri) throws  {
+    let pointer = try rustCallWithError(FfiConverterTypeNostrSdkError.lift) {
     uniffi_nostr_sdk_ffi_fn_constructor_nwc_new(
         FfiConverterTypeNostrWalletConnectURI_lower(uri),$0
     )
@@ -1945,8 +1945,8 @@ open class Nip46Signer:
     /**
      * New NIP46 remote signer
      */
-public convenience init(uri: NostrConnectUri, appKeys: Keys, timeout: TimeInterval, opts: RelayOptions?) {
-    let pointer = throws try rustCallWithError(FfiConverterTypeNostrSdkError.lift) {
+public convenience init(uri: NostrConnectUri, appKeys: Keys, timeout: TimeInterval, opts: RelayOptions?) throws  {
+    let pointer = try rustCallWithError(FfiConverterTypeNostrSdkError.lift) {
     uniffi_nostr_sdk_ffi_fn_constructor_nip46signer_new(
         FfiConverterTypeNostrConnectURI_lower(uri),
         FfiConverterTypeKeys_lower(appKeys),
@@ -3186,8 +3186,8 @@ open class Proxy:
     /**
      * Compose proxy (ex. `127.0.0.1:9050`)
      */
-public convenience init(addr: String) {
-    let pointer = throws try rustCallWithError(FfiConverterTypeNostrSdkError.lift) {
+public convenience init(addr: String) throws  {
+    let pointer = try rustCallWithError(FfiConverterTypeNostrSdkError.lift) {
     uniffi_nostr_sdk_ffi_fn_constructor_proxy_new(
         FfiConverterString.lower(addr),$0
     )
@@ -3459,8 +3459,8 @@ open class Relay:
     /**
      * Create new `Relay` with **default** `options` and `in-memory database`
      */
-public convenience init(url: String) {
-    let pointer = throws try rustCallWithError(FfiConverterTypeNostrSdkError.lift) {
+public convenience init(url: String) throws  {
+    let pointer = try rustCallWithError(FfiConverterTypeNostrSdkError.lift) {
     uniffi_nostr_sdk_ffi_fn_constructor_relay_new(
         FfiConverterString.lower(url),$0
     )


### PR DESCRIPTION
I found out that the current swift files have some syntax errors, multiple `throws try`. They are easy to fix so I went ahead and did it manually but it seems that some steps are failing to produce correct output.

I also noticed that some functions like `EventBuilder::gift_wrap_from_seal` where not included, is this expected or somehow not all features got activated?